### PR TITLE
Fix link to PDF file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A tool for keyframe animation & fragment shader management for 64k executables.
 
 ## Manual
 An extensive PDF can be found in the repo:
-https://github.com/trevorvanhoof/sqrmelon/blob/master/SqrMelon%20manual%2020%20Arp%202018.pdf
+https://github.com/trevorvanhoof/sqrmelon/blob/master/SqrMelon%20manual%2022%20April%202018.pdf
 
 ## Disclaimer
 This tool is provided as-is, feel free to use it, contact me if you have any questions. 


### PR DESCRIPTION
It seems a new PDF file got added. This PR changes the link to that PDF file in the README.