### PR TITLE
install.bat uses the latest Python 3 version available instead of 3.11.

### DIFF
--- a/SqrMelon/install.bat
+++ b/SqrMelon/install.bat
@@ -1,2 +1,23 @@
-"%USERPROFILE%/AppData/Local/Programs/Python/Python311/Scripts/pip.exe" install -r requirements.txt
+@echo off
+setlocal enabledelayedexpansion
+
+rem Search for the most recent version of Python 3 in %LOCALAPPDATA%\Programs\Python.
+set "PYTHON_DIR=%LOCALAPPDATA%\Programs\Python"
+set "LATEST_VERSION=0"
+set "LATEST_PYTHON="
+
+for /D %%d in ("%PYTHON_DIR%\Python3*") do (
+    set "VERSION=%%~nxd"
+    set "VERSION=!VERSION:Python=!"
+    if !VERSION! gtr !LATEST_VERSION! (
+        set "LATEST_VERSION=!VERSION!"
+        set "LATEST_PYTHON=%%d"
+    )
+)
+
+if "%LATEST_PYTHON%"=="" (
+    echo No Python 3 installment found in  %PYTHON_DIR%.
+    exit /b 1
+)
+"%LATEST_PYTHON%\Scripts\pip.exe" install -r requirements.txt
 pause


### PR DESCRIPTION
Companion to PR https://github.com/trevorvanhoof/sqrmelon/pull/28.