### PR TITLE
Fix DoubleSpinBox  unfocus to avoid unchanged values spreading over multiple keys

### DIFF
--- a/SqrMelon/animationgraph/curveview.py
+++ b/SqrMelon/animationgraph/curveview.py
@@ -834,6 +834,9 @@ class CurveEditor(QWidget):
             self.undoStacks()[0].push(edit)
 
     def __onShiftSelectedKeyTimeOrValue(self, widget: DoubleSpinBox, isTime: bool = True) -> None:
+        if not widget.isDirty():
+            return
+        
         keys = self.__view.selectedKeys()
         if self.__relative.value():
             delta = widget.value()

--- a/SqrMelon/qtutil.py
+++ b/SqrMelon/qtutil.py
@@ -6,7 +6,6 @@ from typing import Any, cast, Optional
 
 from qt import *
 
-
 # TODO: floating dockwidget splitter state does not seem to be saved correctly
 
 class QMainWindowState(QMainWindow):
@@ -152,12 +151,19 @@ class DoubleSpinBox(QDoubleSpinBox):
         self.setValue(value)
         self.setSingleStep(0.01)
         self.setLineEdit(LineEditSelected())
+        self.__prevValue = value
 
     def setValueSilent(self, value: float) -> None:
         self.blockSignals(True)
         self.setValue(value)
         self.blockSignals(False)
 
+    def focusInEvent(self, event: QFocusEvent) -> None:
+        self.__prevValue = self.value()
+        super().focusInEvent(event)
+
+    def isDirty(self) -> bool:
+        return self.value() != self.__prevValue
 
 class CheckBox(QCheckBox):
     valueChanged = Signal(int)


### PR DESCRIPTION
**Bug description:**
* Select two keys in the Curve Editor.
* Give focus to "Time" box.
* Change the value.
* Defocus the control (e.g., by pressing TAB).
* Observe that both Time and Value are applied to selected keys.

**Unexpected behavior**
Changing either Time or Value applies both Time and Value to selected keys.

**Expected behavior**
Changing Time should not affect key values and vice versa.