### PR TITLE
PRRC: Fix 3D View Z-order when coming from fullscreen.

### DIFF
--- a/SqrMelon/main.py
+++ b/SqrMelon/main.py
@@ -113,7 +113,7 @@ class App(QMainWindowState):
         viewDock = self._addDockWidget(window, '3D View', where=Qt.DockWidgetArea.TopDockWidgetArea)
         self.__sceneView.setDockWidget(viewDock)
         self.__viewDock = viewDock  # Need this for F11 feature
-        self.__restoreFullScreenInfo: Optional[tuple[QSize, bool]] = None
+        self.__restoreFullScreenInfo: Optional[tuple[QSize, bool, bool]] = None
         logDock = self._addDockWidget(PyDebugLog.create(), 'Python log', where=Qt.DockWidgetArea.TopDockWidgetArea)
         self.tabifyDockWidget(logDock, viewDock)
 
@@ -369,7 +369,7 @@ class App(QMainWindowState):
 
         if not dockWidget.isFullScreen():
             floating = dockWidget.isFloating()
-            self.__restoreFullScreenInfo = dockWidget.size(), floating
+            self.__restoreFullScreenInfo = dockWidget.size(), floating, dockWidget.visibleRegion().isEmpty()
             if not floating:
                 dockWidget.setFloating(True)
             dockWidget.showFullScreen()
@@ -380,6 +380,8 @@ class App(QMainWindowState):
                 dockWidget.setFloating(self.__restoreFullScreenInfo[1])
             if dockWidget.isFloating():
                 dockWidget.resize(self.__restoreFullScreenInfo[0])
+            if not self.__restoreFullScreenInfo[2]:
+                dockWidget.raise_()
 
     def __toggleUILock(self, state: bool) -> None:
         gSettings.setValue('lockui', '1' if state else '0')


### PR DESCRIPTION
Repro steps:
* Dock 3D View in the same docking space than Python Log.
* Click the 3D View tab to bring it to foreground.
* Press F11 to bring 3D View to fullscreen.
* Press F11 to bring 3D View back to docked.
* Observe that 3D View is docked but not in foreground (Python Log is foregrounded instead).

This fix stores the foreground state of 3D View before going to fullscreen and restores it when not floating.